### PR TITLE
Consolidate home page logic

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -26,7 +26,7 @@ baseurl: "" # the subpath of your site, e.g. /blog
 url: "" # the base hostname & protocol for your site, e.g. http://example.com
 twitter_username: jekyllrb
 github_username:  jekyll
-show_blog_on_home: false
+show_blog_on_home: false # set to true to display blog posts on the home page
 
 # Build settings
 theme: minima

--- a/index.html
+++ b/index.html
@@ -1,6 +1,0 @@
-{% if site.show_blog_on_home %}
-  <!-- Move your posts include or loop here. For example: -->
-  {% include posts.html %}
-  <!-- Or, if you had a loop: -->
-  {# {% for post in site.posts %} ... {% endfor %} #}
-{% endif %}

--- a/index.md
+++ b/index.md
@@ -6,3 +6,8 @@ layout: home
 ---
 
 Welcome to your new site!
+
+{% if site.show_blog_on_home %}
+  {% include posts.html %}
+{% endif %}
+


### PR DESCRIPTION
## Summary
- Remove redundant `index.html` so `index.md` is the sole home page
- List blog posts from `index.md` when `show_blog_on_home` is enabled
- Document `show_blog_on_home` configuration option

## Testing
- `bundle install`
- `bundle exec jekyll build`

------
https://chatgpt.com/codex/tasks/task_e_68aca44414ac832b87e8801d5d3a8dd4